### PR TITLE
Update BiLE-weigh.pl

### DIFF
--- a/BiLE-weigh.pl
+++ b/BiLE-weigh.pl
@@ -92,7 +92,7 @@ foreach $blah (keys %sites){
 
 &writenodes;
 
-`cat temp | sort -r -t ":" +1 -n > @ARGV[1].sorted`;
+`cat temp | sort -n -r -t: -k2 > @ARGV[1].sorted`;
 
 
 sub loadnodes{


### PR DESCRIPTION
sort's +1 option is deprecated and can crash in some platforms. It's better to use -k2 option:

`cat temp | sort -n -r -t: -k2 > @ARGV[1].sorted`;
